### PR TITLE
Additional splitting algorithms

### DIFF
--- a/lib/divvy_up/list.rb
+++ b/lib/divvy_up/list.rb
@@ -8,14 +8,18 @@ module DivvyUp
 
     def split(groups)
       return [self.items] if groups == 1
+      determine_best_result(groups)
+    end
+
+    private
+
+    def permute(groups)
       permutations = generate_list_permutations
       permutation_price_differences = calculate_permutation_price_differences(permutations, groups)
       sorted_price_differences = generate_list_combinations(permutation_price_differences)
       list_possibilities = find_full_list(permutation_price_differences, sorted_price_differences)
-      output_final_lists(list_possibilities, groups)
+      calculate_list_totals(list_possibilities, groups)
     end
-
-    private
 
     def snake(groups)
       unassigned_items = self.items.sort_by { |item, price| price }.to_a
@@ -31,7 +35,7 @@ module DivvyUp
           unassigned_items.pop
         end
       end
-      permutations
+      calculate_list_totals(permutations, groups)
     end
 
     def price_is_right(groups)
@@ -50,6 +54,7 @@ module DivvyUp
           end unless permutation == permutations.last
         end
       end
+      calculate_list_totals(permutations, groups)
     end
 
     def target_amount(divisor)
@@ -109,7 +114,7 @@ module DivvyUp
       output
     end
 
-    def output_final_lists(lists, groups)
+    def calculate_list_totals(lists, groups)
       output = []
       accounted_items = []
       until output.size == groups
@@ -122,6 +127,10 @@ module DivvyUp
         end
       end
       output
+    end
+
+    def determine_best_result(groups)
+      permute(groups)
     end
   end
 end

--- a/lib/divvy_up/list.rb
+++ b/lib/divvy_up/list.rb
@@ -51,7 +51,7 @@ module DivvyUp
           if total > target_amount(groups)
             permutation.delete(next_item.first)
             unassigned_items << next_item
-          end unless permutation == permutations.last
+          end unless permutation == permutations.last || permutation.count == 1
         end
       end
       calculate_list_totals(permutations, groups)
@@ -130,7 +130,22 @@ module DivvyUp
     end
 
     def determine_best_result(groups)
-      permute(groups)
+      permute_result = permute(groups)
+      snake_result = snake(groups)
+      price_is_right_result = price_is_right(groups)
+      results = [permute_result, snake_result, price_is_right_result]
+      target = target_amount(groups)
+      result_differences = []
+      results.each do |result|
+        result_totals = []
+        result.each do |list|
+          result_totals << list.last
+        end
+        min_difference = (result_totals.min - target).abs
+        max_difference = (result_totals.max - target).abs
+        result_differences << (min_difference > max_difference ? min_difference : max_difference)
+      end
+      results[result_differences.index(result_differences.min)]
     end
   end
 end

--- a/lib/divvy_up/list.rb
+++ b/lib/divvy_up/list.rb
@@ -17,6 +17,20 @@ module DivvyUp
 
     private
 
+    def snake(groups)
+      unassigned_items = self.items.sort_by { |item, price| price }.to_a
+      permutations = []
+      groups.times { permutations << [] }
+      until unassigned_items.empty? do
+        permutations.each do |permutation|
+          permutation << unassigned_items.pop
+        end
+        permutations.reverse_each do |permutation|
+          permutation << unassigned_items.pop
+        end
+      end
+    end
+
     def target_amount(divisor)
       (self.items.values.reduce(:+) / divisor).round(2)
     end

--- a/lib/divvy_up/list.rb
+++ b/lib/divvy_up/list.rb
@@ -31,6 +31,22 @@ module DivvyUp
       end
     end
 
+    def price_is_right(groups)
+      unassigned_items = self.items.sort_by { |item, price| price }.to_a
+      permutations = []
+      groups.times { permutations << [] }
+      permutations.each do |permutation|
+        total = 0
+        until total > target_amount(groups) || unassigned_items.empty? do
+          permutation << unassigned_items.pop
+          total = permutation.to_h.values.reduce(:+).nil? ? 0 : permutation.to_h.values.reduce(:+)
+          if total > target_amount(groups)
+            unassigned_items << permutation.pop
+          end unless permutation == permutations.last
+        end
+      end
+    end
+
     def target_amount(divisor)
       (self.items.values.reduce(:+) / divisor).round(2)
     end

--- a/lib/divvy_up/list.rb
+++ b/lib/divvy_up/list.rb
@@ -20,28 +20,33 @@ module DivvyUp
     def snake(groups)
       unassigned_items = self.items.sort_by { |item, price| price }.to_a
       permutations = []
-      groups.times { permutations << [] }
+      groups.times { permutations << {} }
       until unassigned_items.empty? do
         permutations.each do |permutation|
-          permutation << unassigned_items.pop
+          permutation[unassigned_items.last.first] = unassigned_items.last.last
+          unassigned_items.pop
         end
         permutations.reverse_each do |permutation|
-          permutation << unassigned_items.pop
+          permutation[unassigned_items.last.first] = unassigned_items.last.last unless unassigned_items.empty?
+          unassigned_items.pop
         end
       end
+      permutations
     end
 
     def price_is_right(groups)
       unassigned_items = self.items.sort_by { |item, price| price }.to_a
       permutations = []
-      groups.times { permutations << [] }
+      groups.times { permutations << {} }
       permutations.each do |permutation|
         total = 0
         until total > target_amount(groups) || unassigned_items.empty? do
-          permutation << unassigned_items.pop
-          total = permutation.to_h.values.reduce(:+).nil? ? 0 : permutation.to_h.values.reduce(:+)
+          next_item = unassigned_items.pop
+          permutation[next_item.first] = next_item.last
+          total = permutation.values.reduce(:+).nil? ? 0 : permutation.values.reduce(:+)
           if total > target_amount(groups)
-            unassigned_items << permutation.pop
+            permutation.delete(next_item.first)
+            unassigned_items << next_item
           end unless permutation == permutations.last
         end
       end

--- a/spec/divvy_up/list_spec.rb
+++ b/spec/divvy_up/list_spec.rb
@@ -42,13 +42,37 @@ module DivvyUp
                                    [{bananas: 2.40, pears: 3.20}, 5.60]])
     end
 
-    it "split a list into three groups" do
+    it "splits a list into three groups" do
       list = DivvyUp::List.new(shopping_list)
       expect(list.split(3)).to eql(
         [
           [{orange_juice: 3, eggs: 2.79, carrots: 2.5, onion: 1.25, celery: 1.69}, 11.23],
           [{lettuce: 7, strawberries: 3, tomato: 1.25}, 11.25],
           [{blueberries: 3.99, butter: 2.69, pasta_sauce: 2.5, pepper: 2}, 11.18]
+        ]
+      )
+    end
+
+    it "splits a list using the 'snake' technique" do
+      shopping_list = { orange_juice: 3, colored_pepper: 1.99, spring_mix_7_oz: 4.99, pasta_sauce: 2.50, blueberries: 3.99, onion: 1.25 }
+      list = DivvyUp::List.new(shopping_list)
+      expect(list.split(3)).to eql(
+        [
+          [{spring_mix_7_oz: 4.99, onion: 1.25}, 6.24],
+          [{blueberries: 3.99, colored_pepper: 1.99}, 5.98],
+          [{orange_juice: 3, pasta_sauce: 2.5}, 5.5]
+        ]
+      )
+    end
+
+    it "splits a list using the 'price is right' technique" do
+      shopping_list = { milk: 2.49, bread: 1.99, cheese: 3.50, celery: 2.99, yogurt: 2.99, ham: 4.99, potatoes: 2, belvita_bars: 3.49, rice: 5, chicken: 6.49 }
+      list = DivvyUp::List.new(shopping_list)
+      expect(list.split(3)).to eql(
+        [
+          [{chicken: 6.49, rice: 5}, 11.49],
+          [{ham: 4.99, cheese: 3.5, belvita_bars: 3.49}, 11.98],
+          [{yogurt: 2.99, celery: 2.99, milk: 2.49, potatoes: 2, bread: 1.99}, 12.46]
         ]
       )
     end


### PR DESCRIPTION
The original technique for splitting generates various list permutations, sorts them by proximity to the target price, and outputs a list as part of the final result if it does not have any duplicate items. This works well for splitting two ways, but can become less accurate when splitting three ways or more.

To remedy this, now the code will also generate results using a "snake" technique and "price is right" technique. The snake method sorts all of the items by price, and assigns them to each output group going forward, and then in reverse, until all items are allocated. The price is right method starts with the highest-priced items, and allocates them to one output group, and stops before a next items would push it over the target price. Any remaining items are allocated to the last group.

The lists within each result are inspected to determine which total price is furthest from the target price. These prices are compared, and whichever one has the smallest difference is used. This ensures that a list containing an outlier total is not used.

This resolves some edge cases where results were not optimally balanced.