### PR TITLE
Fix issue with program freezing during permute method

### DIFF
--- a/lib/divvy_up/list.rb
+++ b/lib/divvy_up/list.rb
@@ -113,15 +113,14 @@ module DivvyUp
     def output_final_sublists(sublist_options_sorted)
       sublists = []
       accounted_items = []
-      until sublists.size == @groups
-        sublist_options_sorted.each do |list|
-          if (accounted_items & list.keys).empty?
-            sublists << [list, (list.values.reduce(:+)).round(2)]
-            accounted_items << list.keys
-            accounted_items.flatten!
-          end
+      sublist_options_sorted.each do |list|
+        if (accounted_items & list.keys).empty?
+          sublists << [list, (list.values.reduce(:+)).round(2)]
+          accounted_items << list.keys
+          accounted_items.flatten!
         end
       end
+      sublists = nil if sublists.count > @groups
       sublists
     end
 
@@ -130,6 +129,7 @@ module DivvyUp
       snake_result = snake
       price_is_right_result = price_is_right
       results = [permute_result, snake_result, price_is_right_result]
+      results.delete(nil)
       result_differences = []
       results.each do |result|
         result_totals = []

--- a/spec/divvy_up/list_spec.rb
+++ b/spec/divvy_up/list_spec.rb
@@ -87,5 +87,17 @@ module DivvyUp
         ]
       )
     end
+
+    it "splits a large list into three groups" do
+      shopping_list = { orange_juice_1: 3, orange_juice_2: 3, eggs_dozen: 2.99, spring_mix_16_oz: 6.99, bacon: 4.99, pasta_sauce: 2.50, blueberries: 3.99, frozen_strawberries: 2.99, olive_oil: 8.99, paper_towels: 1.59, toilet_paper: 1.99, aluminum_foil: 3 }
+      list = DivvyUp::List.new(shopping_list)
+      expect(list.split(3)).to eql(
+        [
+          [{olive_oil:8.99, orange_juice_1:3, orange_juice_2:3, paper_towels:1.59}, 16.58],
+          [{spring_mix_16_oz:6.99, aluminum_foil:3, frozen_strawberries:2.99, toilet_paper:1.99}, 14.97],
+          [{bacon:4.99, blueberries:3.99, eggs_dozen:2.99, pasta_sauce:2.5}, 14.47]
+        ]
+      )
+    end
   end
 end


### PR DESCRIPTION
The last step of the permute method (output_final_sublists) would iterate through all of the sorted sublist options, and shovel lists containing no duplicates into the final array (sublists). The bug presented itself when the the remaining sublist options contained duplicates before the number of sublists reached the number of groups. This caused the until loop condition to run infinitely.

This commit removes the until loop, and checks afterward if we have more sublists than desired groups. If the result is invalid, it is set to nil, and removed before the comparison step. There is not currently a test for when the sublist needs to be nullified, it is unlikely that this result would be the final result returned.

Fixes #2 