### PR TITLE
Allow specifying item quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+## [0.2.0] - 2015-08-04
 ### Added
 - Allow specifying item price via hash attribute
 - Allow specifying quantity of item via hash attribute
@@ -22,7 +24,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 0.0.1 - 2015-03-09
 - Initial release
 
-[unreleased]: https://github.com/djpowers/divvy_up/compare/v0.1.2...HEAD
+[unreleased]: https://github.com/djpowers/divvy_up/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/djpowers/divvy_up/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/djpowers/divvy_up/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/djpowers/divvy_up/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/djpowers/divvy_up/compare/v0.0.1...v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Allow specifying item price via hash attribute
+- Allow specifying quantity of item via hash attribute
 
 ## [0.1.2] - 2015-07-09
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ shopping_list = {
   orange_juice: 3,
   lettuce: 7,
   strawberries: 3,
-  eggs: 2.79,
+  eggs: { price: 2.79 },
   carrots: 2.5,
   onion: 1.25,
   tomato: 1.25,

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or install it yourself as:
 
 ```ruby
 shopping_list = {
-  orange_juice: 3,
+  orange_juice: { price: 3, quantity: 2 },
   lettuce: 7,
   strawberries: 3,
   eggs: { price: 2.79 },

--- a/README.md
+++ b/README.md
@@ -44,11 +44,17 @@ shopping_list = {
 DivvyUp::List.new(shopping_list).split(3)
 # =>
 # [
-#   [{:orange_juice=>3, :eggs=>2.79, :carrots=>2.5, :onion=>1.25, :celery=>1.69}, 11.23],
-#   [{:lettuce=>7, :strawberries=>3, :tomato=>1.25}, 11.25],
-#   [{:blueberries=>3.99, :butter=>2.69, :pasta_sauce=>2.5, :pepper=>2}, 11.18]
+#   [{:eggs=>2.79, :carrots=>2.5, :onion=>1.25, :butter=>2.69, :pepper=>2}, 11.23],
+#   [{:tomato=>1.25, :blueberries=>3.99, :orange_juice_1=>3, :orange_juice_2=>3}, 11.24],
+#   [{:lettuce=>7, :pasta_sauce=>2.5, :celery=>1.69}, 11.19]
 # ]
 ```
+
+Pass a hash as an argument when creating a new List, where the keys are the item
+names, and the values are the prices, as an integer or float.
+
+Optionally, you may specify the price in an attributes hash. If you have more
+than one of an item, you can specify the quantity here as well.
 
 Output of `#split` method consists of an array of arrays, where each subarray
 is a hash of items and the total value of those items.

--- a/lib/divvy_up/list.rb
+++ b/lib/divvy_up/list.rb
@@ -3,7 +3,7 @@ module DivvyUp
     attr_reader :items
 
     def initialize(items)
-      @items = items
+      @items = parse_items(items)
     end
 
     def split(groups)
@@ -13,6 +13,15 @@ module DivvyUp
     end
 
     private
+
+    def parse_items(items)
+      items.each do |item, attributes|
+        next if attributes.is_a? Numeric
+        if attributes[:quantity].nil?
+          items[item] = attributes[:price]
+        end
+      end
+    end
 
     def permute
       sublists = sublist_permutations

--- a/lib/divvy_up/list.rb
+++ b/lib/divvy_up/list.rb
@@ -15,12 +15,19 @@ module DivvyUp
     private
 
     def parse_items(items)
+      quantified_items = {}
       items.each do |item, attributes|
         next if attributes.is_a? Numeric
-        if attributes[:quantity].nil?
-          items[item] = attributes[:price]
+        items[item] = attributes[:price]
+        if attributes[:quantity]
+          attributes[:quantity].times do |index|
+            item_name = (item.to_s + '_' + (index + 1).to_s).to_sym
+            quantified_items[item_name] = attributes[:price]
+            items.delete(item)
+          end
         end
       end
+      items.merge(quantified_items)
     end
 
     def permute

--- a/lib/divvy_up/version.rb
+++ b/lib/divvy_up/version.rb
@@ -1,3 +1,3 @@
 module DivvyUp
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/spec/divvy_up/list_spec.rb
+++ b/spec/divvy_up/list_spec.rb
@@ -1,9 +1,8 @@
 module DivvyUp
   describe List do
     let(:shopping_list) { {
-        orange_juice: 3,
+        orange_juice: { price: 3, quantity: 2 },
         lettuce: 7,
-        strawberries: 3,
         eggs: { price: 2.79 },
         carrots: 2.5,
         onion: 1.25,
@@ -27,7 +26,9 @@ module DivvyUp
 
     it "splits a list into one group" do
       list = DivvyUp::List.new(shopping_list)
-      expect(list.split(1)).to eql([shopping_list])
+      expect(list.split(1)).to eql(
+        [{:lettuce=>7, :eggs=>2.79, :carrots=>2.5, :onion=>1.25, :tomato=>1.25, :blueberries=>3.99, :butter=>2.69, :pasta_sauce=>2.5, :pepper=>2, :celery=>1.69, :orange_juice_1=>3, :orange_juice_2=>3}]
+      )
     end
 
     it "splits a two-item list into two groups" do
@@ -46,9 +47,9 @@ module DivvyUp
       list = DivvyUp::List.new(shopping_list)
       expect(list.split(3)).to eql(
         [
-          [{orange_juice: 3, eggs: 2.79, carrots: 2.5, onion: 1.25, celery: 1.69}, 11.23],
-          [{lettuce: 7, strawberries: 3, tomato: 1.25}, 11.25],
-          [{blueberries: 3.99, butter: 2.69, pasta_sauce: 2.5, pepper: 2}, 11.18]
+          [{:eggs=>2.79, :carrots=>2.5, :onion=>1.25, :butter=>2.69, :pepper=>2}, 11.23],
+          [{:tomato=>1.25, :blueberries=>3.99, :orange_juice_1=>3, :orange_juice_2=>3}, 11.24],
+          [{:lettuce=>7, :pasta_sauce=>2.5, :celery=>1.69}, 11.19]
         ]
       )
     end

--- a/spec/divvy_up/list_spec.rb
+++ b/spec/divvy_up/list_spec.rb
@@ -4,7 +4,7 @@ module DivvyUp
         orange_juice: 3,
         lettuce: 7,
         strawberries: 3,
-        eggs: 2.79,
+        eggs: { price: 2.79 },
         carrots: 2.5,
         onion: 1.25,
         tomato: 1.25,
@@ -42,7 +42,7 @@ module DivvyUp
                                    [{bananas: 2.40, pears: 3.20}, 5.60]])
     end
 
-    it "splits a list into three groups" do
+    it "splits a list with attributes hash into three groups" do
       list = DivvyUp::List.new(shopping_list)
       expect(list.split(3)).to eql(
         [


### PR DESCRIPTION
The items hash (passed as an argument when creating a new `List`), now accepts hash values for each item, to specify a `price` or `quantity`. This allows duplicate items to be added. A number will be appended to each duplicate item to keep each one unique.

Fixed #4
